### PR TITLE
open-nvfwupd 1.0.1 Release

### DIFF
--- a/cli_schema.yaml
+++ b/cli_schema.yaml
@@ -20,7 +20,7 @@ GlobalOptions:
   Usage: "[-t BMC-TARGET] [-v] < command >"
   Options:
     - Target:
-        Description: BMC target comprising BMC IP address and BMC login credentials. servertype and port are optional. Valid value for servertype is one of [DGX, HGX, HGXB100, GB200, MGX-NVL, GB200Switch]
+        Description: BMC target comprising BMC IP address and BMC login credentials. servertype and port are optional. Valid value for servertype is one of [DGX, HGX, HGXB100, GB200, GB300, MGX-NVL, GB200Switch]
         Short: t
         Long: target
         Arg: ip=<BMC IP> user=<BMC login id> password=<BMC password> port=<port num for port forwarding> servertype=<Type of server>
@@ -73,6 +73,10 @@ Commands:
        Action: store_true
        Required: false
        Validator: validate_recipe
+     - Description: Show staged firmware versions
+       Short: 's'
+       Long: 'staged'
+       Action: store_true
   - Name: update_fw
     Class: UpdateFirmware
     RequireGlobalOption: true
@@ -111,6 +115,15 @@ Commands:
         Action: store_true
         Required: false
         Validator: validate_recipe
+      - Description: SPI Staged Update
+        Short: u
+        Long: staged_update
+        Action: store_true
+      - Description: SPI and Activate Staged Update
+        Short: a
+        Long: staged_activate_update
+        Action: store_true
+
   - Name: force_update
     Class: ForceUpdate
     RequireGlobalOption: true

--- a/firmware_update_guide/docs/appendix/output-formatting.rst
+++ b/firmware_update_guide/docs/appendix/output-formatting.rst
@@ -1,0 +1,121 @@
+OPEN-NVFWUPD Table Output Formatting
+===============================
+
+Overview
+--------
+The open-nvfwupd tool provides detailed table output format when using the -d flag with the update_fw command, displaying comprehensive debugging information and thorough firmware update progress reporting.
+Command:
+::
+
+    ./nvfwupd.py -t ip=1.1.1.1 user=**** password=**** servertype=GB200 -v update_fw -d -s compute_full.json -p ../nvfw_GB200-P4975_0004_250325.1.0_prod-signed.fwpkg
+
+Output:
+::
+
+    Updating ip address: ip=XXXX
+    FW package: ['../nvfw_GB200-P4975_0004_250325.1.0_prod-signed.fwpkg']
+    Ok to proceed with firmware update? <Y/N>
+    Y
+
+    {"@odata.id": "/redfish/v1/TaskService/Tasks/HGX_9", "@odata.type": "#Task.v1_4_3.Task", "Id": "HGX_9", "TaskState": "Running", "TaskStatus": "OK"}
+    FW update started, Task Id: HGX_9
+    Wait for Firmware Update to Start...
+
+    +---------------------------+--------------------------------------------------------+
+    | MessageId                 | Message                                                |
+    +===========================+========================================================+
+    | TaskEvent.1.0.3.TaskStart | The task with Id '9' has started.                      |
+    | ed                        |                                                        |
+    +---------------------------+--------------------------------------------------------+
+    | NvidiaUpdate.1.0.0.DebugT | The operation to erase a debug token for device        |
+    | okenEraseFailed           | 'HGX_FW_Debug_Token_Erase' has failed with error       |
+    |                           | 'Operation timed out.'                                 |
+    +---------------------------+--------------------------------------------------------+
+    | Update.1.0.TargetDetermin | The target device 'HGX_FW_ERoT_CPU_0' will be          |
+    | ed                        | updated with image '01.04.0008.0000_n04'.              |
+    +---------------------------+--------------------------------------------------------+
+    | Update.1.0.TargetDetermin | The target device 'HGX_FW_CPU_0' will be               |
+    | ed                        | updated with image '02.03.16'.                         |
+    +---------------------------+--------------------------------------------------------+
+    | Update.1.0.TargetDetermin | The target device 'HGX_FW_ERoT_CPU_1' will be          |
+    | ed                        | updated with image '01.04.0008.0000_n04'.              |
+    +---------------------------+--------------------------------------------------------+
+    | Update.1.0.TargetDetermin | The target device 'HGX_FW_CPU_1' will be               |
+    | ed                        | updated with image '02.03.16'.                         |
+    +---------------------------+--------------------------------------------------------+
+    | Update.1.0.TargetDetermin | The target device 'HGX_FW_ERoT_BMC_0' will be          |
+    | ed                        | updated with image '01.04.0008.0000_n04'.              |
+    +---------------------------+--------------------------------------------------------+
+    | Update.1.0.TargetDetermin | The target device 'HGX_FW_BMC_0' will be               |
+    | ed                        | updated with image 'GB200Nvl-25.01-7'.                 |
+    +---------------------------+--------------------------------------------------------+
+    | Update.1.0.TransferringTo | Image ' ' is being transferred to                      |
+    | Component                 | 'HGX_PCIeSwitchConfig_0'.                              |
+    +---------------------------+--------------------------------------------------------+
+    | NvidiaUpdate.1.0.Componen | The update operation for the component                 |
+    | tUpdateSkipped            | 'HGX_FW_ERoT_BMC_0' is skipped because                 |
+    |                           | 'Component image is identical'.                        |
+    +---------------------------+--------------------------------------------------------+
+    | NvidiaUpdate.1.0.Componen | The update operation for the component                 |
+    | tUpdateSkipped            | 'HGX_FW_ERoT_CPU_1' is skipped because                 |
+    |                           | 'Component image is identical'.                        |
+    +---------------------------+--------------------------------------------------------+
+    | NvidiaUpdate.1.0.Componen | The update operation for the component                 |
+    | tUpdateSkipped            | 'HGX_FW_ERoT_CPU_0' is skipped because                 |
+    |                           | 'Component image is identical'.                        |
+    +---------------------------+--------------------------------------------------------+
+    | Update.1.0.TransferringTo | Image 'GB200Nvl-25.01-7' is being transferred to       |
+    | Component                 | 'HGX_FW_BMC_0'.                                        |
+    +---------------------------+--------------------------------------------------------+
+    | Update.1.0.TransferringTo | Image '02.03.16' is being transferred to               |
+    | Component                 | 'HGX_FW_CPU_1'.                                        |
+    +---------------------------+--------------------------------------------------------+
+    | Update.1.0.TransferringTo | Image '02.03.16' is being transferred to               |
+    | Component                 | 'HGX_FW_CPU_0'.                                        |
+    +---------------------------+--------------------------------------------------------+
+    | Update.1.0.TransferringTo | Image '0.1C' is being transferred to 'MAX10 CPLD'.     |
+    | Component                 |                                                        |
+    +---------------------------+--------------------------------------------------------+
+    | Update.1.0.UpdateSuccessf | Device 'HGX_PCIeSwitchConfig_0' successfully updated   |
+    | ul                        | with image ''.                                         |
+    +---------------------------+--------------------------------------------------------+
+    | TaskEvent.1.0.3.TaskProgr | The task with Id '9' has changed to progress 20 percent|
+    | essChanged                | complete.                                              |
+    +---------------------------+--------------------------------------------------------+
+    | Update.1.0.UpdateSuccessf | Device 'MAX10 CPLD' successfully updated with image    |
+    | ul                        | '0.1C'.                                                |
+    +---------------------------+--------------------------------------------------------+
+    | Update.1.0.UpdateSuccessf | Device 'HGX_FW_CPU_0' successfully updated with image  |
+    | ul                        | '02.03.16'.                                            |
+    +---------------------------+--------------------------------------------------------+
+    | Update.1.0.AwaitToActivat | Awaiting for an action to proceed with activating image|
+    | e                         | '02.03.16' on 'HGX_FW_CPU_0'.                          |
+    +---------------------------+--------------------------------------------------------+
+    | Update.1.0.UpdateSuccessf | Device 'HGX_FW_CPU_1' successfully updated with image  |
+    | ul                        | '02.03.16'.                                            |
+    +---------------------------+--------------------------------------------------------+
+    | Update.1.0.AwaitToActivat | Awaiting for an action to proceed with activating image|
+    | e                         | '02.03.16' on 'HGX_FW_CPU_1'.                          |
+    +---------------------------+--------------------------------------------------------+
+    | TaskEvent.1.0.3.TaskProgr | The task with Id '9' has changed to progress 40 percent|
+    | essChanged                | complete.                                              |
+    +---------------------------+--------------------------------------------------------+
+    | Update.1.0.UpdateSuccessf | Device 'HGX_FW_BMC_0' successfully updated with image  |
+    | ul                        | 'GB200Nvl-25.01-7'.                                    |
+    +---------------------------+--------------------------------------------------------+
+    | Update.1.0.AwaitToActivat | Awaiting for an action to proceed with activating image|
+    | e                         | 'GB200Nvl-25.01-7' on 'HGX_FW_BMC_0'.                  |
+    +---------------------------+--------------------------------------------------------+
+    | TaskEvent.1.0.3.TaskProgr | The task with Id '9' has changed to progress 100       |
+    | essChanged                | percent complete.                                      |
+    +---------------------------+--------------------------------------------------------+
+    | TaskEvent.1.0.3.TaskCompl | The task with Id '9' has completed.                    |
+    | etedOK                    |                                                        |
+    +---------------------------+--------------------------------------------------------+
+
+The output will conclude with:
+::
+
+    Firmware update successful!
+    Overall Time Taken: 0:10:58
+    Refer to 'NVIDIA Firmware Update Document' on activation steps for new firmware to take effect.

--- a/firmware_update_guide/docs/appendix/platform-agnostic-updates.rst
+++ b/firmware_update_guide/docs/appendix/platform-agnostic-updates.rst
@@ -12,7 +12,7 @@ The tool supports various configuration parameters and ``BMC_IP``, ``RF_USERNAME
 
 .. code-block:: yaml
 
-   # Define target platform as one of HGX / DGX / GB200 / HGXB100 / MGX-NVL / GB200Switch
+   # Define the target platform as one of HGX/DGX/GB200/GB300/HGXB100/MGX-NVL/GB200Switch.
    TargetPlatform: 'DGX'
    # Disable Sanitize Log, disabling Sanitize Log leads to print system IP and user credential to the logs and screen
    SANITIZE_LOG: False

--- a/firmware_update_guide/docs/appendix/spi-staged.rst
+++ b/firmware_update_guide/docs/appendix/spi-staged.rst
@@ -1,0 +1,100 @@
+SPI Staged Update
+----------------------------------------------------------------------------
+SPI Staged Updates allow you to download firmware component images in advance for the supported components, which reduces the downtime during firmware updates and activation.
+
+GB200 NVL and GB300 NVL BMC/Compute trays support staged updates.
+
+To begin SPI staging an update, run the ``update_fw`` command with the ``-u`` flag or the ``--staged_update`` option. This will only stage, but not activate, the firmware images.
+
+.. code-block::
+
+    nvfwupd.py -t ip=1.1.1.1 user=<username> password=<password> update_fw -p nvfw_GB200-P4972_0011_250404.1.0_prod-signed.fwpkg -s BMC_Full.json -u
+    Updating ip address: ip=XXXX
+    FW package: ['nvfw_GB200-P4972_0011_250404.1.0_prod-signed.fwpkg']
+    Ok to proceed with firmware update? <Y/N>
+    y
+    {"@odata.id": "/redfish/v1/TaskService/Tasks/0", "@odata.type": "#Task.v1_4_3.Task", "Id": "0", "TaskState": "Running", "TaskStatus": "OK"}
+    FW update started, Task Id: 0
+    Wait for Firmware Update to Start...
+    TaskState: Running
+    PercentComplete: 20
+    TaskStatus: OK
+    TaskState: Running
+    PercentComplete: 40
+    TaskStatus: OK
+    TaskState: Completed
+    PercentComplete: 100
+    TaskStatus: OK
+    Firmware update successful!
+    Overall Time Taken: 0:11:35
+    Refer to 'NVIDIA Firmware Update Document' on activation steps for new firmware to take effect.
+    ------------------------------------------------------------------------------------------------------------------------
+    Error Code: 0
+
+After the update is finished, to view the staged components with the system and package versions, run the ``show_version`` command with the ``-s`` flag or the ``--staged`` option.
+
+.. code-block::
+
+    nvfwupd.py -t ip=1.1.1.1 user=<username> password=<password> show_version -p nvfw_GB200-P4972_0011_250404.1.0_prod-signed.fwpkg -s
+    System Model: GB200 NVL
+    Part number: 699-24764-0001-TS3
+    Serial number: 1333124010358
+    Packages: ['GB200-P4972_0011_250404.1.0']
+    Connection Status: Successful
+
+    Firmware Devices:
+    AP Name                  Sys Version         Staged Version  Pkg Version   Up-To-Date
+    -------                  -----------         --------------  -----------   ----------
+    FW_BMC_0                 GB200Nvl-25.01      GB200Nvl-25.02 GB200Nvl-25.02 No       
+    FW_ERoT_BMC_0            01.04.0007_n04      01.04.0008_n04 01.04.0008_n04 No       
+    Full_FW_Image_NIC_Slot_4 32.41.1300          N/A            N/A            No        
+    Full_FW_Image_NIC_Slot_7 32.41.1300          N/A            N/A            No        
+    UEFI                     buildbrain-gcid-397 N/A            N/A            No        
+    HGX_FW_BMC_0             GB200Nvl-25.02-D    N/A            N/A            No        
+    HGX_FW_CPLD_0            0.1D                N/A            N/A            No        
+    HGX_FW_CPU_0             02.03.22            N/A            N/A            No        
+    HGX_FW_CPU_1             02.03.22            N/A            N/A            No        
+    HGX_FW_ERoT_BMC_0        01.04.0008.0000_n04 N/A            N/A            No        
+    HGX_FW_ERoT_CPU_0        01.04.0008.0000_n04 N/A            N/A            No        
+    HGX_FW_ERoT_CPU_1        01.04.0008.0000_n04 N/A            N/A            No        
+    HGX_FW_ERoT_FPGA_0       01.04.0008.0000_n04 N/A            N/A            No        
+    HGX_FW_ERoT_FPGA_1       01.04.0008.0000_n04 N/A            N/A            No        
+    HGX_FW_FPGA_0            1.2E                N/A            N/A            No        
+    HGX_FW_FPGA_1            1.2E                N/A            N/A            No        
+    HGX_FW_GPU_0             97.00.16.00.00      N/A            N/A            No        
+    HGX_FW_GPU_1             97.00.16.00.00      N/A            N/A            No        
+    HGX_FW_GPU_2             97.00.16.00.00      N/A            N/A            No        
+    HGX_FW_GPU_3             97.00.16.00.00      N/A            N/A            No        
+    HGX_PCIeSwitchConfig_0   01170424            N/A            N/A            No        
+    -------------------------------------------------------------------------------------
+    Error Code: 0
+
+Now that the component images have been staged, they can be quickly activated by using the same package and the ``-a`` flag or the ``--staged_activate_update`` option with the ``update_fw`` command.
+Do not use the ``force_update`` option to use staged component images because the component images would be downloaded again.
+
+.. code-block::
+
+    nvfwupd.py -t ip=1.1.1.1 user=<username> password=<password> update_fw -p nvfw_GB200-P4972_0011_250404.1.0_prod-signed.fwpkg -a
+    Updating ip address: ip=XXXX
+    FW package: ['nvfw_GB200-P4972_0011_250404.1.0_prod-signed.fwpkg']
+    Ok to proceed with firmware update? <Y/N>
+    y
+    {"@odata.id": "/redfish/v1/TaskService/Tasks/1", "@odata.type": "#Task.v1_4_3.Task", "Id": "1", "TaskState": "Running", "TaskStatus": "OK"}
+    FW update started, Task Id: 1
+    Wait for Firmware Update to Start...
+    TaskState: Running
+    PercentComplete: 20
+    TaskStatus: OK
+    TaskState: Running
+    PercentComplete: 40
+    TaskStatus: OK
+    TaskState: Completed
+    PercentComplete: 100
+    TaskStatus: OK
+    Firmware update successful!
+    Overall Time Taken: 0:01:15
+    Refer to 'NVIDIA Firmware Update Document' on activation steps for new firmware to take effect.
+    ------------------------------------------------------------------------------------------------------------------------
+    Error Code: 0
+
+When you use staged component images, the update takes less time. After the update is complete, to activate the images, complete the power cycle activation process.

--- a/firmware_update_guide/docs/examples/gb200NVL.rst
+++ b/firmware_update_guide/docs/examples/gb200NVL.rst
@@ -20,7 +20,7 @@ To update the complete BMC tray:
 
 1. Create a JSON file like the ``BMC_Full.json`` file in the example.
 
-2. Use the nvfwupd tool and run the update_fw command.
+2. Use the ``nvfwupd.py`` tool and run the ``update_fw`` command.
 
 In the package name, the BMC tray update packages can be identified by ``GB200-P4972``.
 
@@ -38,7 +38,7 @@ Here is the output:
         "Targets": []
     }
 
-    $ nvfwupd.py -t ip=<BMC IP> user=*** password=*** - update_fw -s BMC_Full.json -p nvfw_GB200-P4972_0004_240808.1.1_custom_prod-signed.fwpkg
+    $ nvfwupd.py -t ip=<BMC IP> user=*** password=*** update_fw -s BMC_Full.json -p nvfw_GB200-P4972_0004_240808.1.1_custom_prod-signed.fwpkg
 
     Updating ip address: ip=XXXX
     FW package: ['nvfw_GB200-P4972_0004_240808.1.1_custom_prod-signed.fwpkg']
@@ -62,6 +62,9 @@ Here is the output:
     ---------------------------------------------------------------------------------------
     Error Code: 0
 
+.. note::
+    For open-nvfwupd 1.0.1 and later, the ``-s`` option is no longer required when updating the entire BMC tray. The default "Targets" are all components without ``force_update``.
+
 Updating the GB200 NVL Compute Tray
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -69,7 +72,7 @@ To update the compute tray:
 
 1. Create a JSON file, like the ``Compute_Full.json`` file, in the example.
 
-2. Use the ``nvfwupd`` tool and run the update_fw command.
+2. Use the ``nvfwupd.py`` tool and run the ``update_fw`` command.
 
 In the package name, the Compute tray update packages can be identified by ``GB200-P4975``.
 
@@ -234,7 +237,7 @@ To complete a firmware update of a component:
     $ cat CPU.json
 
     {
-        "Targets":["/redfish/v1/UpdateService/FirmwareInventory/HGX_CPU_0"]
+        "Targets":["/redfish/v1/UpdateService/FirmwareInventory/HGX_FW_CPU_0"]
     }
 
     $ nvfwupd.py --target ip=<BMC IP> user=*** password=*** servertype=GB200 update_fw -s CPU.json -p nvfw_GB200-P4975_0004_240717.1.0_custom_prod-signed.fwpkg
@@ -324,7 +327,7 @@ To display the current versions of switch tray components, run the show_version 
     Error Code: 0
 
 .. note::
-    The ``SSD``, ``transceiver``, and ``ASIC`` can only be updated using inband update methods. These components cannot be updated using nvfwupd.
+    The ``SSD``, ``transceiver``, and ``ASIC`` can only be updated using inband update methods. These components cannot be updated using open-nvfwupd.
 
 Full Bundle Firmware Update for GB200 NVL Switch Components
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/firmware_update_guide/docs/examples/gb300NVL.rst
+++ b/firmware_update_guide/docs/examples/gb300NVL.rst
@@ -1,0 +1,282 @@
+GB300 NVL Update Examples
+-------------------------
+
+The firmware update mechanism for GB300 NVL is different from the update mechanism for MGX in the following ways:
+
+-  GB300 NVL uses two fwpkg bundles.
+
+    - The **P4058** packages are for the BMC tray.
+    - The **P4059** packages are for the compute tray.
+
+-  The update targets file are passed with the ``–s`` option, which can be used to specify the update target for the BMC and compute trays (refer to the sample outputs in the :ref:`next section <gb300_updates>`).
+
+-  To downgrade the GB300 NVL BMC or compute tray firmware, set the ``ForceUpdate`` flag in the update target JSON file that is passed with the ``–s`` option.
+
+.. _gb300_updates:
+
+Updating the GB300 NVL BMC Tray
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To update the complete BMC tray:
+
+1. Create a JSON file like the ``BMC_Full.json`` file in the example.
+
+2. Use the ``nvfwupd.py`` tool and run the ``update_fw`` command.
+
+In the package name, the BMC tray update packages can be identified by ``GB300-P4058``.
+
+1. After the update successfully completes, to activate the firmware, complete a power cycle.
+
+2. After the BMC is up and the Redfish service is running, to determine whether the BMC tray components were updated and they match the versions in the package, run the ``show_version`` command.
+
+Here is the output:
+
+.. code-block::
+
+    $ cat BMC_Full.json
+
+    {
+        "Targets": []
+    }
+
+    nvfwupd.py -t ip=<BMC_IP> user=**** password=**** servertype=GB300 update_fw -p nvfw_GB300-P4058_0001_250422.1.0_prod-signed.fwpkg -s BMC_Full.json
+
+    Updating ip address: ip=XXXX
+    FW package: ['nvfw_GB300-P4058_0001_250422.1.0_prod-signed.fwpkg ']
+    Ok to proceed with firmware update? <Y/N>
+    y
+    {"@odata.id": "/redfish/v1/TaskService/Tasks/1", "@odata.type": "#Task.v1_4_3.Task", "Id": "1", "TaskState": "Running", "TaskStatus": "OK"}
+    FW update started, Task Id: 1
+    Wait for Firmware Update to Start...
+    TaskState: Running
+    PercentComplete: 20
+    TaskStatus: OK
+    TaskState: Running
+    PercentComplete: 40
+    TaskStatus: OK
+    TaskState: Completed
+    PercentComplete: 100
+    TaskStatus: OK
+    Firmware update successful!
+    Overall Time Taken: 0:10:35
+    Refer to 'NVIDIA Firmware Update Document' on activation steps for new firmware to take effect.
+    ------------------------------------------------------------------------------------------------------------------------
+    Error Code: 0
+
+.. note::
+    For open-nvfwupd 1.0.1 and later, the ``-s`` option is no longer required when updating the entire BMC tray. The default "Targets" are all components without ``force_update``.
+
+Updating the GB300 NVL Compute Tray
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To update the compute tray:
+
+1. Create a JSON file, like the ``Compute_Full.json`` file, in the example.
+
+2. Use the ``nvfwupd.py`` tool and run the ``update_fw`` command.
+
+In the package name, the Compute tray update packages can be identified by ``GB300-P4059``.
+
+1. After the update successfully completes, to activate the firmware, complete an AC cycle.
+
+2. After the BMC is up and the Redfish service is running again, to determine whether the compute tray components were updated and they match the versions in the package, run the ``show_version`` command.
+
+Here is an example:
+
+.. code-block::
+
+    $ cat Compute_Full.json
+
+    {
+        "Targets": ["/redfish/v1/Chassis/HGX_Chassis_0"]
+    }
+
+    $ nvfwupd.py -t ip=<BMC IP> user=*** password=*** servertype=GB300 update_fw -s Compute_Full.json -p nvfw_GB300-P4059_0002_250422.1.0_custom_prod-signed.fwpkg
+
+    Updating ip address: ip=XXXX
+    FW package: ['nvfw_GB300-P4059_0002_250422.1.0_custom_prod-signed.fwpkg']
+    Ok to proceed with firmware update? <Y/N>
+    y
+    {"@odata.id": "/redfish/v1/TaskService/Tasks/HGX_1", "@odata.type": "#Task.v1_4_3.Task", "Id": "HGX_1", "TaskState": "Running", "TaskStatus": "OK"}
+    FW update started, Task Id: HGX_1
+    Wait for Firmware Update to Start...
+    TaskState: Running
+    PercentComplete: 20
+    TaskStatus: OK
+    TaskState: Running
+    PercentComplete: 40
+    TaskStatus: OK
+    TaskState: Completed
+    PercentComplete: 100
+    TaskStatus: OK
+    Firmware update successful!
+    Overall Time Taken: 0:11:20
+    Refer to 'NVIDIA Firmware Update Document' on activation steps for new firmware to take effect.
+    ------------------------------------------------------------------------------------------------------------------------
+    Error Code: 0
+
+
+.. note::
+    For open-nvfwupd 1.0.1 and later, the ``-s`` option is no longer required when updating the entire Compute tray. The default "Targets" are all components without ``force_update``.
+
+GB300 NVL Firmware Downgrades Using the Force Update Option
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To downgrade the GB300 NVL firmware, you must use the force update multipart option, which can be set in the update parameters JSON file targets, and are passed in the JSON file with the ``–s`` option. If you try firmware updates as described in the previous sections, and you see the following error message in the firmware update log:
+
+.. note::
+    The Component comparison stamp is lower than the firmware component comparison stamp in the FD.
+
+Retry with a force firmware update but change the Targets value based on the tray you want to force update.
+
+For example, to force update the BMC tray on the target:
+
+1. Create a JSON file, like the ``force_BMC_Full.json`` file, in the example.
+
+2. Run the tool.
+
+Here is an example:
+
+.. code-block::
+    :emphasize-lines: 4
+
+    $ cat force_BMC_Full.json
+
+    {
+        "ForceUpdate":true,
+        "Targets":[]
+
+    }
+
+    $ nvfwupd.py -t ip=<BMC IP> user=*** password=**** servertype=GB300 update_fw -s force_BMC_Full.json -p nvfw_GB300-P4058_0001_250422.1.0_prod-signed.fwpkg
+
+    Updating ip address: ip=XXXX
+    FW package: ['nvfw_GB300-P4058_0001_250422.1.0_prod-signed.fwpkg']
+    Ok to proceed with firmware update? <Y/N>
+    y
+    {"@odata.id": "/redfish/v1/TaskService/Tasks/0", "@odata.type": "#Task.v1_4_3.Task", "Id": "0", "TaskState": "Running", "TaskStatus": "OK"}
+    FW update started, Task Id: 0
+    Wait for Firmware Update to Start...
+    TaskState: Running
+    PercentComplete: 20
+    TaskStatus: OK
+    TaskState: Running
+    PercentComplete: 40
+    TaskStatus: OK
+    TaskState: Completed
+    PercentComplete: 100
+    TaskStatus: OK
+    Firmware update successful!
+    Overall Time Taken: 0:10:38
+
+    Refer to 'NVIDIA Firmware Update Document' on activation steps for new firmware to take effect.
+    ---------------------------------------------------------------------------------------
+    Error Code: 0
+
+GB300 NVL Firmware Updates for Selected Components
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To complete a firmware update of a component:
+
+1. Identify the inventory name of the component.
+
+   -  The ``show_version`` option can be used to list all the components in the inventory with their current versions.
+
+   -  Components names that are prefixed with **HGX** can be updated using a compute tray package, and the rest of the components will need the BMC tray package.
+
+.. code-block ::
+
+    nvfwupd.py -t ip=<BMC_IP> user=**** password=**** show_version -p nvfw_GB300-P4058_0000_250422.1.0_prod-signed.fwpkg nvfw_GB300-P4059_0002_250422.1.0_custom_prod-signed.fwpkg
+
+    System Model: GB300 NVL
+    Part number: 699-24764-0004-TS2
+    Serial number: 1330425200012
+    Packages: ['GB300-P4058_0000_250422.1.0', 'GB300-P4059_0002_250422.1.0_custom']
+    Connection Status: Successful
+
+    Firmware Devices:
+    AP Name                 Sys Version                 Pkg Version           Up-To-Date
+    -------                 -----------                 -----------           ----------
+    FW_BMC_0                GB3-2503-02.0               GB3-2503-04.0         No        
+    FW_CPLD_0               0x00 0x0c 0x06 0x04         C_06_04               Yes       
+    FW_CPLD_1               0x00 0x0c 0x06 0x04         C_06_04               Yes       
+    FW_CPLD_2               0x00 0x0c 0x06 0x04         C_06_04               Yes        
+    FW_CPLD_3               0x00 0x0c 0x06 0x04         C_06_04               Yes        
+    FW_ERoT_BMC_0           01.04.0008.0000_n04         01.04.0008.0000_n04   Yes       
+    NIC_1                   32.41.1300                  N/A                   No        
+    SMA_0                   0010.00.0131.0000           0010.00.0145.0000     No        
+    SMA_1                   0010.00.0131.0000           0010.00.0145.0000     No        
+    UEFI                    buildbrain-gcid-39352899    N/A                   No        
+    HGX_FW_BMC_0            GB3-2503-04.0               GB3-2503-04.0         Yes       
+    HGX_FW_CPLD_0           0.1C                        0.1C                  Yes       
+    HGX_FW_CPU_0            3.0.4_dot                   03.00.05              Yes       
+    HGX_FW_CPU_1            3.0.4_dot                   03.00.05              Yes       
+    HGX_FW_ERoT_BMC_0       01.04.0008.0000_n04         01.04.0008.0000_n04   Yes       
+    HGX_FW_ERoT_CPU_0       01.04.0008.0000_n04         01.04.0008.0000_n04   Yes       
+    HGX_FW_ERoT_CPU_1       01.04.0008.0000_n04         01.04.0008.0000_n04   Yes       
+    HGX_FW_ERoT_FPGA_0      01.04.0008.0000_n04         01.04.0008.0000_n04   Yes       
+    HGX_FW_FPGA_0           0.30                        0.32                  No        
+    HGX_FW_GPU_0            97.10.12.00.00              97.10.12.00.01        No        
+    HGX_FW_GPU_1            97.10.12.00.00              97.10.12.00.01        No        
+    HGX_FW_GPU_2            97.10.06.00.00              N/A                   No        
+    HGX_FW_GPU_3            97.10.06.00.00              N/A                   No        
+    HGX_InfoROM_GPU_0       G540.0211.00.05             N/A                   No        
+    HGX_InfoROM_GPU_1       G540.0211.00.05             N/A                   No        
+    HGX_InfoROM_GPU_2       G540.0211.00.05             N/A                   No        
+    HGX_InfoROM_GPU_3       G540.0211.00.05             N/A                   No        
+    HGX_PCIeSwitchConfig_0  01300524                    N/A                   No        
+    HGX_SXM_MCU_0           0004.00.0123.0000           N/A                   No        
+    HGX_SXM_MCU_1           0004.00.0123.0000           N/A                   No        
+    HGX_SXM_MCU_2           0004.00.0123.0000           N/A                   No        
+    HGX_SXM_MCU_3           0004.00.0123.0000           N/A                   No        
+    -----------------------------------------------------------------------------------
+    Error Code: 0
+
+
+2. After identifying the inventory name, create the JSON file with the Redfish inventory URI of that component (``/redfish/v1/UpdateService/FirmwareInventory/<component name>``).
+
+   The example in step 4 shows a sample ``CPU.json`` file that is used to update only the ``HGX_FW_CPU_0`` component on the tray.
+
+3.  Run the ``update_fw`` command with the ``CPU.json`` file and compute tray bundle as the inputs.
+
+4.  To perform a downgrade, add the ``"ForceUpdate": true`` field to this JSON file.
+
+.. code-block:: 
+
+    $ cat CPU.json
+
+    {
+        "Targets":["/redfish/v1/UpdateService/FirmwareInventory/HGX_FW_CPU_0"]
+    }
+
+    $ nvfwupd.py --target ip=<BMC IP> user=*** password=*** servertype=GB300 update_fw -s CPU.json -p nvfw_GB300-P4059_0002_250422.1.0_custom_prod-signed.fwpkg
+
+    Updating ip address: ip=XXXX
+    FW package: ['nvfw_GB300-P4059_0002_250422.1.0_custom_prod-signed.fwpkg']
+    Ok to proceed with firmware update? <Y/N>
+    y
+    {"@odata.id": "/redfish/v1/TaskService/Tasks/HGX_3", "@odata.type": "#Task.v1_4_3.Task", "Id": "HGX_3", "TaskState": Running", "TaskStatus": "OK"}
+      FW update started, Task Id: HGX_3
+    Wait for Firmware Update to Start...
+      TaskState: Running
+      PercentComplete: 20
+      TaskStatus: OK
+      TaskState: Running
+      PercentComplete: 40
+      TaskStatus: OK
+      TaskState: Completed
+      PercentComplete: 100
+      TaskStatus: OK
+      Firmware update successful!
+
+    Overall Time Taken: 0:09:50
+
+    Refer to 'NVIDIA Firmware Update Document' on activation steps for new firmware to take effect.
+    ---------------------------------------------------------------------------------------
+    Error Code: 0
+
+
+Activating the Firmware
+~~~~~~~~~~~~~~~~~~~~~~~
+
+After performing firmware update of a component, or a full bundle, complete an AC power cycle to activate the new firmware. It can take up to five minutes for the BMC and Redfish service to come up after power cycle is complete. To check new system versions after the BMC Redfish service is back, run the show version command.

--- a/firmware_update_guide/docs/history.rst
+++ b/firmware_update_guide/docs/history.rst
@@ -2,6 +2,12 @@
 Document History 
 =================
 
+* **1.0.1** - May 12, 2025
+
+  - Added support for SPI staged updates.
+  - Added support for GB300 NVL
+  - If no special update file is provided for updates, added default update parameters for GB200 NVL.
+
 * **1.0.0** - March 31, 2025
 
   - Initial Release of open-nvfwupd

--- a/firmware_update_guide/docs/index.rst
+++ b/firmware_update_guide/docs/index.rst
@@ -9,6 +9,7 @@ Firmware Update Guide
 
     introduction
     examples/gb200NVL
+    examples/gb300NVL
     examples/verbose
     examples/log-sanitization
 
@@ -22,6 +23,8 @@ Firmware Update Guide
     Parallel Update Support <appendix/parallel-update>
     Full Rack Parallel Update <appendix/full-rack-parallel-update>
     JSON Options For Automation <appendix/json-options>
+    SPI Staged Update Support <appendix/spi-staged>
+    Output Formatting <appendix/output-formatting>
 
 .. toctree::
     :hidden:

--- a/firmware_update_guide/docs/introduction.rst
+++ b/firmware_update_guide/docs/introduction.rst
@@ -39,7 +39,7 @@ Supported Platforms
 
 The following platforms are supported in Grace Blackwell:
 
--  NVIDIA GB200 NVL
+-  NVIDIA GB200 NVL, NVIDIA GB300 NVL
 
 
 Updating Grace Blackwell Firmware
@@ -86,7 +86,7 @@ Command Syntax
 
   Global options:
       -t --target ip=<BMC IP> user=<BMC login id> password=<BMC password> port=<port num for port forwarding> servertype=<Type of server>
-            BMC target comprising BMC IP address and BMC login credentials. servertype and port are optional. Valid value for servertype is one of [DGX, HGX, HGXB100, GB200, MGX-NVL, GB200Switch]
+            BMC target comprising BMC IP address and BMC login credentials. servertype and port are optional. Valid value for servertype is one of [DGX, HGX, HGXB100, GB200, GB300, MGX-NVL, GB200Switch]
 
       -c --config Path for config file (optional).
             Configure tool behavior
@@ -101,7 +101,8 @@ Command Syntax
 
       <Global options...> show_version [ options... ]
           -p  --package                PLDM firmware package                                       
-          -j  --json                   show output in JSON                                         
+          -j  --json                   show output in JSON
+          -s  --staged                 Show staged firmware versions                                  
 
       <Global options...> update_fw [ options... ]
           -p  --package                PLDM firmware package                                       
@@ -111,6 +112,8 @@ Command Syntax
           -s  --special                Special Update json file                                    
           -d  --details                Show update progress in table format                        
           -j  --json                   show output in JSON. Must be paired with the -b background option, and always bypasses update confirmation prompt.
+          -u  --staged_update          SPI Staged Update                                           
+          -a  --staged_activate_update SPI and Activate Staged Update
 
       <Global options...> force_update [ options... ]
           enable|disable|status        enable, disable or check current force update value on target

--- a/nvfwupd/base_rftarget.py
+++ b/nvfwupd/base_rftarget.py
@@ -41,7 +41,7 @@ class BaseRFTarget(RFTarget):
     -------
     version_newer(pkg_version, sys_version) :
         Determines if package or system firmware version is newer
-    update_component(param_list, update_uri, update_file, time_out,
+    update_component(cmd_args, update_uri, update_file, time_out,
                          json_dict=None, parallel_update=False) :
         Update a firmware component or target system
     is_fungible_component(component_name) :
@@ -97,7 +97,7 @@ class BaseRFTarget(RFTarget):
     # pylint: disable=too-many-positional-arguments
     def update_component(
         self,
-        param_list,
+        cmd_args,
         update_uri,
         update_file,
         time_out,
@@ -107,7 +107,7 @@ class BaseRFTarget(RFTarget):
         """
         Method to perform FW update using redfish requests
         Parameters:
-            param_list List or file of special parameters used for the update
+            cmd_args Parsed input command arguments
             update_uri Target Redfish URI used for the update
             update_file File used for the update
             time_out Timeout period in seconds for the requests
@@ -119,6 +119,9 @@ class BaseRFTarget(RFTarget):
         """
         special_targets = ""
         task_id = ""
+        # cmd_args.special - User passed in JSON Update Parameters or file with Update Parameters
+        param_list = cmd_args.special
+
         if param_list is not None:
             if self.validate_json(param_list):
                 special_targets = param_list
@@ -195,7 +198,7 @@ class BaseRFTarget(RFTarget):
             True if the package is an HGX package or
             False if the package is not an HGX package
         """
-        hgx_platforms = ["HGX", "4764", "4974", "4975", "MGX-NVL16"]
+        hgx_platforms = ["HGX", "4059", "4764", "4974", "4975", "MGX-NVL16"]
         if next((platform for platform in hgx_platforms if platform in pkg_name), None):
             return True
         return False

--- a/nvfwupd/config.yaml
+++ b/nvfwupd/config.yaml
@@ -1,4 +1,4 @@
-# Define target platform as one of HGX / DGX / GB200 / HGXB100 / MGX-NVL / GB200Switch
+# Define target platform as one of HGX / DGX / GB200 / GB300 / HGXB100 / MGX-NVL / GB200Switch
 TargetPlatform: 'DGX'
 # Provide full path of firmware file(s) to be used for firmware update. Value is a list
 FWUpdateFilePath: 
@@ -16,7 +16,7 @@ FwUpdateMethod: "MultipartHttpPushUri"
 # Optional Parameter used with MultipartHttpPushUri update method
 # used to define dict of parameters for multipart FW update
 MultipartOptions:
-  - ForceUpdate: True
+    ForceUpdate: True
 
 # Target IP address. BMC IP/NVOS Rest service IP/localhost for port forwarding
 BMC_IP: "1.1.1.1"

--- a/nvfwupd/config_target.py
+++ b/nvfwupd/config_target.py
@@ -62,7 +62,7 @@ class ConfigTarget(RFTarget):
         Acquire the update URI from the Redfish update service
     get_task_service_uri(task_id) :
         Acquire the task service URI from Redfish for task monitoring
-    update_component(param_list, update_uri, update_file, time_out,
+    update_component(cmd_args, update_uri, update_file, time_out,
                          json_dict=None, parallel_update=False) :
         Update a firmware component or target system
     start_update_monitor(recipe_list, pkg_parser, cmd_args, time_out,
@@ -123,7 +123,7 @@ class ConfigTarget(RFTarget):
             self.config_platform_target = MGXNVLRFTarget(self.target_access)
         elif target_platform == "dgx":
             self.config_platform_target = DGX_RFTarget(self.target_access)
-        elif target_platform == "gb200":
+        elif target_platform in ("gb200", "gb300"):
             self.config_platform_target = GB200RFTarget(self.target_access)
         elif target_platform == "gb200switch":
             self.config_platform_target = GB200SwitchTarget(self.target_access)
@@ -253,7 +253,7 @@ class ConfigTarget(RFTarget):
     # pylint: disable=too-many-positional-arguments
     def update_component(
         self,
-        param_list,
+        cmd_args,
         update_uri,
         update_file,
         time_out,
@@ -264,7 +264,7 @@ class ConfigTarget(RFTarget):
         check update config param and call multipart update or http push uri
         read update targets param list from the config into a json
         Parameters:
-            param_list List of special parameters used for the update
+            cmd_args Parsed input command arguments
             update_uri Target URI used for the update
             update_file File used for the update
             time_out Timeout period in seconds for the requests
@@ -317,7 +317,7 @@ class ConfigTarget(RFTarget):
             )
         elif self.config_platform_target:
             task_id = self.config_platform_target.update_component(
-                param_list,
+                cmd_args,
                 update_uri,
                 update_file,
                 time_out,

--- a/nvfwupd/dut_access.py
+++ b/nvfwupd/dut_access.py
@@ -105,7 +105,7 @@ class DUTAccess:
             if Util.is_sanitize:
                 target_str = Util.sanitize_log(target_str)
             for each in global_args.target:
-                tokens = Util.get_tokens(each, "=")
+                tokens = each.split("=", 1)
                 if len(tokens) < 2:
                     if not json_dict:
                         print(len(tokens))
@@ -1080,9 +1080,6 @@ class BMCLoginAccess(DUTAccess):
                         )
                         return False, my_dict
         except requests.exceptions.RequestException as excpt:
-            DUTAccess.dut_logger.verbose_log(
-                f"Error: Error sending HTTPs request: {excpt}"
-            )
             if not suppress_err:
                 Util.bail_nvfwupd(
                     1,
@@ -1276,12 +1273,21 @@ class BMCLoginAccess(DUTAccess):
             pkg_file_fd.close()
             if params_file_fd is not None:
                 params_file_fd.close()
-            Util.bail_nvfwupd_threadsafe(
-                1,
-                f"Error: Error sending HTTPs request: {excpt.response}",
-                print_json=json_prints,
-                parallel_update=parallel_update,
-            )
+            if excpt.response is None:
+                # Print the exception even in non-verbose cases if the response is None
+                Util.bail_nvfwupd_threadsafe(
+                    1,
+                    f"Error: Error sending HTTPs request: {excpt}",
+                    print_json=json_prints,
+                    parallel_update=parallel_update,
+                )
+            else:
+                Util.bail_nvfwupd_threadsafe(
+                    1,
+                    f"Error: Error sending HTTPs request: {excpt.response}",
+                    print_json=json_prints,
+                    parallel_update=parallel_update,
+                )
         return status, response_dict
 
 

--- a/nvfwupd/gb200_rftarget.py
+++ b/nvfwupd/gb200_rftarget.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 """Class that defines update related behavior for GB200"""
 import re
+import os
+import json
 from nvfwupd.base_rftarget import BaseRFTarget
+from nvfwupd.utils import Util
 
 
 class GB200RFTarget(BaseRFTarget):
@@ -39,14 +42,19 @@ class GB200RFTarget(BaseRFTarget):
     -------
     get_update_uri(update_service_response) :
         Acquire the update URI from the Redfish update service
-    update_component(param_list, update_uri, update_file, time_out,
+    update_component(cmd_args, update_uri, update_file, time_out,
                          json_dict=None, parallel_update=False) :
         Update a firmware component or target system
     is_fungible_component(component_name) :
         Determines if a component is fungible for a given system
     version_newer(pkg_version, sys_version) :
         Determines if package or system firmware version is newer
-
+    get_identifier_from_chassis(ap_inv_uri) :
+        Acquire a component's unique identifier for comparison
+    get_model_from_chassis(ap_name) :
+        Acquire a component's model for comparison
+    get_version_sku(identifier, pldm_version_dict, ap_name)
+        Acquire a package version for a component with given identifier
     """
 
     def __init__(self, dut_access):
@@ -79,7 +87,7 @@ class GB200RFTarget(BaseRFTarget):
     # pylint: disable=too-many-positional-arguments
     def update_component(
         self,
-        param_list,
+        cmd_args,
         update_uri,
         update_file,
         time_out,
@@ -90,7 +98,7 @@ class GB200RFTarget(BaseRFTarget):
         Method to perform FW update using mutipart redfish request for GB200
         returns task id
         Parameters:
-            param_list List or file of special parameters used for the update
+            cmd_args Parsed input command arguments
             update_uri Target Redfish URI used for the update
             update_file File used for the update
             time_out Timeout period in seconds for the requests
@@ -99,6 +107,47 @@ class GB200RFTarget(BaseRFTarget):
         Returns:
             Task ID of the update task
         """
+
+        # cmd_args.special - User passed in JSON Update Parameters or file with Update Parameters
+        param_list = cmd_args.special
+
+        # Check if special update file was provided
+        if param_list is None:
+            file_name = os.path.basename(update_file)
+            hgx_platforms = ["P4059", "P4764", "P4974", "P4975", "HGX"]
+            if next(
+                (platform for platform in hgx_platforms if platform in file_name), None
+            ):
+                # GPU Tray Update
+                json_params = {"Targets": ["/redfish/v1/Chassis/HGX_Chassis_0"]}
+            else:
+                # BMC Tray Update
+                json_params = {"Targets": []}
+            param_list = json.dumps(json_params)
+
+        # Set Staged Update Parameters
+        if cmd_args.staged_update or cmd_args.staged_activate_update:
+            # read in params and append the OEM options
+            if param_list is not None and self.validate_json(param_list):
+                json_data = json.loads(param_list)
+            elif param_list is not None and os.path.isfile(param_list[0]):
+                try:
+                    with open(param_list[0], "r", encoding="utf-8") as file:
+                        json_data = json.load(file)
+                except json.JSONDecodeError:
+                    Util.bail_nvfwupd(
+                        1,
+                        "Error: Invalid JSON special update file",
+                        Util.BailAction.DO_NOTHING,
+                        print_json=json_dict,
+                    )
+
+            # Add the OEM parameters for staging
+            if cmd_args.staged_update:
+                json_data["Oem"] = {"Nvidia": {"UpdateOption": "StageOnly"}}
+            elif cmd_args.staged_activate_update:
+                json_data["Oem"] = {"Nvidia": {"UpdateOption": "StageAndActivate"}}
+            param_list = json.dumps(json_data)
 
         task_id = ""
         if param_list is not None and self.validate_json(param_list):
@@ -133,6 +182,9 @@ class GB200RFTarget(BaseRFTarget):
             True if the component is fungible,
             False if the component is not fungible
         """
+        # Special Handling required for BMC Tray CPLD
+        if "cpld" in component_name and "hgx" not in component_name:
+            return True
         if any(map(component_name.__contains__, self.fungible_components)) and not any(
             map(component_name.__contains__, ["inforom", "erot"])
         ):
@@ -161,3 +213,84 @@ class GB200RFTarget(BaseRFTarget):
             if end_match is not None:
                 sys_version = sys_version[: end_match.start()]
         return super().version_newer(pkg_version, sys_version)
+
+    def get_identifier_from_chassis(self, ap_inv_uri):
+        """
+        Get Redfish Chassis uri for getting sku id
+        Parameter:
+            ap_inv_uri The Redfish inventory URI for a component
+        Returns:
+            SKU ID value for the given URI or
+            None if there was an error or SKU is not available
+        """
+        ap_name = ap_inv_uri.rsplit("/", 1)[-1]
+        if "cpld" in ap_name.lower():
+            return self.get_model_from_chassis(ap_name)
+
+        sku_id = None
+        status, fw_inv_dict = self.target_access.dispatch_request(
+            "GET", ap_inv_uri, None, suppress_err=True
+        )
+        if status is True:
+            try:
+                chassis_uri = fw_inv_dict.get("RelatedItem")[0]["@odata.id"]
+            except (KeyError, IndexError, TypeError):
+                return sku_id
+            status, chassis_dict = self.target_access.dispatch_request(
+                "GET", chassis_uri, None
+            )
+            if status is True:
+                sku_id = chassis_dict.get("SKU")
+        return sku_id
+
+    def get_model_from_chassis(self, ap_name):
+        """
+        Get Redfish Chassis uri for getting CPLD model
+        Parameter:
+            ap_name A component string name
+        Returns:
+            Model string for the given component or
+            None if there was an error or Model is not available
+        """
+        ap_chassis = ap_name.replace("FW_", "")
+        status, cpld_dict = self.target_access.dispatch_request(
+            "GET", "/redfish/v1/Chassis/" + ap_chassis, None, suppress_err=True
+        )
+        if status is False or cpld_dict is None:
+            self.target_access.dut_logger.cli_log(
+                f"Chassis URI failed to return: {ap_name}", log_file_only=True
+            )
+            return None
+        model = cpld_dict.get("Model")
+        if model is None:
+            self.target_access.dut_logger.cli_log(
+                f"CPLD Model not present: {ap_name}", log_file_only=True
+            )
+
+        if model == "BP":
+            # Redfish model is shortened as BP
+            # Metadata spells this out fully, adjust to match
+            model = "Backplane"
+        return model
+
+    def get_version_sku(self, identifier, pldm_version_dict, ap_name):
+        """
+        Get pkg version for gpu with matching sku_id
+        Parameters:
+            identifier A string identifier used to match a package component
+            pldm_version_dict A dictionary of package names alongside
+            their contained component information
+            ap_name Unused
+        Returns:
+            Pkg version for a GPU or CPLD with matching identifier or
+            N/A if not found
+        """
+        for _, pkg_dict in pldm_version_dict.items():
+            for pkg_ap, pkg_data in pkg_dict.items():
+                if "gpu" in pkg_ap.lower():
+                    if pkg_data[1] == identifier:
+                        return pkg_data[0]
+                if "cpld" in pkg_ap.lower():
+                    if identifier.lower() in pkg_ap.lower():
+                        return pkg_data[0]
+        return "N/A"

--- a/nvfwupd/gb200_switch_target.py
+++ b/nvfwupd/gb200_switch_target.py
@@ -52,7 +52,7 @@ class GB200SwitchTarget(RFTarget):
         Acquire target name for a given bundle component name
     upload_image(file_path, ap_name, parallel_update, print_json=None) :
         Upload an image using scp to the target system
-    update_component(param_list, update_uri, update_file, time_out,
+    update_component(cmd_args, update_uri, update_file, time_out,
                          json_dict=None, parallel_update=False) :
         Unused method (Returns empty string)
     get_update_file(target_comp, pkg_parser) :
@@ -192,7 +192,7 @@ class GB200SwitchTarget(RFTarget):
     # pylint: disable=too-many-positional-arguments
     def update_component(
         self,
-        param_list,
+        cmd_args,
         update_uri,
         update_file,
         time_out,

--- a/nvfwupd/utils.py
+++ b/nvfwupd/utils.py
@@ -324,6 +324,7 @@ class Util:
             "dgx",
             "hgx",
             "gb200",
+            "gb300",
             "hgxb100",
             "mgx-nvl",
             "gb200switch",

--- a/nvfwupd/version.py
+++ b/nvfwupd/version.py
@@ -16,4 +16,4 @@
 CLI version
 """
 
-NVFWUPD_CLI_VERSION = "1.0.0"
+NVFWUPD_CLI_VERSION = "1.0.1"

--- a/nvfwupd_manpage.1
+++ b/nvfwupd_manpage.1
@@ -26,7 +26,7 @@ Password to login to the target BMC or NVSwitch Tray.
 .IP port
 TCP port with port-forwarding to use to connect with BMC service (optional)
 .IP servertype
-User can provide servertype value from one of [DGX | HGX | HGXB100 | GB200 | MGX-NVL | GB200Switch] based on the type of the target system. This is optional and recommeded only to aid usage in case of unknown platform errors.
+Users can provide the servertype value from the [DGX | HGX | HGXB100 | GB200 | GB300 | MGX-NVL | GB200Switch] options based on the type of the target system type. This is optional and is recommended only if you experience unknown platform errors.
 .RE
 .RE
 .TP
@@ -45,6 +45,8 @@ Show AP components that can be updated out-of-band along with current running fi
 PLDM firmware package or firmware tar file. (optional)
 .IP -j/--json 0.20i
 Display package comparison in JSON format. (optional)
+.IP -s/--staged 0.20i
+Display staged firmware versions. (optional)
 .RE
 .TP
 .BR "update_fw <command options>"
@@ -65,6 +67,10 @@ Show update progress in table format.
 Bypass firmware update confirmation prompt.
 .IP -j/--json
 Show output in JSON. Must be paired with the -b background option, and always bypasses update confirmation prompt.
+.IP -u/--staged_update
+Run a SPI staged update for components that support it. (optional)
+.IP -a/--staged_activate_update
+Run a SPI staged and activate update for components that support it. (optional)
 .RE
 .TP
 .BR "force_update <option_value> <command options>"

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1,3 +1,12 @@
+May 12, 2025
+
+CLI version: 1.0.1
+
+- SPI Staged Update Support
+- GB300 Servertype Support
+- Added default update parameters for DGX and GB200 NVL if no special update file provided for updates
+- Minor Bugfixes
+
 March 31, 2025
 
 CLI version: 1.0.0


### PR DESCRIPTION
- Added support for SPI staged updates.
- Added support for GB300 NVL
- If no special update file is provided for updates, added default update parameters for GB200 NVL.
- Minor Bugfixes